### PR TITLE
Missing a G_END_DECLS macro

### DIFF
--- a/src/gtkosxapplication.h
+++ b/src/gtkosxapplication.h
@@ -143,5 +143,6 @@ gchar *quartz_application_get_executable_path(void);
 gchar *quartz_application_get_bundle_id(void);
 gchar *quartz_application_get_bundle_info(const gchar *key);
 
+G_END_DECLS
 
 #endif /* __GTK_OSX_APPLICATION_H__ */


### PR DESCRIPTION
Hi,

I'm no GTK expert, but I think you are missing the `G_END_DECLS` macro in the `gtkosxapplication.h` header.

-Roy
