### PR TITLE
Get gtk_mac_bundle_get_resourcesdir back to the API

### DIFF
--- a/src/gtk-mac-bundle.c
+++ b/src/gtk-mac-bundle.c
@@ -22,7 +22,6 @@
  * -psn_... arguments?
  */
 
-#ifndef __x86_64__
 #include <gtk/gtk.h>
 #include <Carbon/Carbon.h>
 
@@ -35,6 +34,7 @@ struct GtkMacBundlePriv {
   gchar       *path;
   gchar       *id;
   gchar       *datadir;
+  gchar       *resourcesdir;
   gchar       *localedir;
   UInt32       type;
   UInt32       creator;
@@ -140,6 +140,7 @@ mac_bundle_finalize (GObject *object)
   g_free (priv->path);
   g_free (priv->id);
   g_free (priv->datadir);
+  g_free (priv->resourcesdir);
   g_free (priv->localedir);
 
   CFRelease (priv->cf_bundle);
@@ -253,6 +254,25 @@ gtk_mac_bundle_get_datadir (GtkMacBundle *bundle)
     }
 
   return priv->datadir;
+}
+
+const gchar *
+gtk_mac_bundle_get_resourcesdir (GtkMacBundle *bundle)
+{
+  GtkMacBundlePriv *priv = GET_PRIV (bundle);
+
+  if (!gtk_mac_bundle_get_is_app_bundle (bundle))
+    return NULL;
+
+  if (!priv->resourcesdir)
+    {
+      priv->resourcesdir = g_build_filename (priv->path,
+                                        "Contents",
+                                        "Resources",
+                                        NULL);
+    }
+
+  return priv->resourcesdir;
 }
 
 const gchar *
@@ -376,5 +396,3 @@ gtk_mac_bundle_get_resource_path (GtkMacBundle *bundle,
 
   return path;
 }
-
-#endif //__x86_64__

--- a/src/gtk-mac-bundle.h
+++ b/src/gtk-mac-bundle.h
@@ -21,7 +21,6 @@
 #ifndef __GTK_MAC_BUNDLE_H__
 #define __GTK_MAC_BUNDLE_H__
 
-#ifndef __x86_64__
 #include <glib-object.h>
 
 G_BEGIN_DECLS
@@ -53,6 +52,7 @@ const gchar * gtk_mac_bundle_get_path          (GtkMacBundle *bundle);
 gboolean      gtk_mac_bundle_get_is_app_bundle (GtkMacBundle *bundle);
 const gchar * gtk_mac_bundle_get_localedir     (GtkMacBundle *bundle);
 const gchar * gtk_mac_bundle_get_datadir       (GtkMacBundle *bundle);
+const gchar * gtk_mac_bundle_get_resourcesdir  (GtkMacBundle *bundle);
 gchar *       gtk_mac_bundle_get_resource_path (GtkMacBundle *bundle,
                                                 const gchar  *name,
                                                 const gchar  *type,
@@ -60,5 +60,4 @@ gchar *       gtk_mac_bundle_get_resource_path (GtkMacBundle *bundle,
 
 G_END_DECLS
 
-#endif /* __x86_64__*/
 #endif /* __GTK_MAC_BUNDLE_H__ */

--- a/src/gtk-mac-dock.c
+++ b/src/gtk-mac-dock.c
@@ -18,7 +18,6 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#ifndef __x86_64__
 /* FIXME: Add example like this to docs for the open documents stuff:
 
     <key>CFBundleDocumentTypes</key>
@@ -464,4 +463,3 @@ gtk_mac_attention_type_get_type (void)
   return 0;
 }
 
-#endif // __x86_64__

--- a/src/gtk-mac-dock.h
+++ b/src/gtk-mac-dock.h
@@ -23,7 +23,6 @@
 
 #ifndef __GTK_MAC_DOCK_H__
 #define __GTK_MAC_DOCK_H__
-#ifndef __x86_64__
 
 #include <gtk/gtk.h>
 #include <gtk-mac-bundle.h>
@@ -84,5 +83,4 @@ GType                   gtk_mac_attention_type_get_type        (void);
 
 G_END_DECLS
 
-#endif /* __x86_64__ */
 #endif /* __GTK_MAC_DOCK_H__ */

--- a/src/gtk-mac-menu.c
+++ b/src/gtk-mac-menu.c
@@ -23,7 +23,6 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#ifndef __x86_64__
 #include "config.h"
 
 #include <gtk/gtk.h>
@@ -1266,4 +1265,3 @@ gtk_mac_menu_sync(GtkMenuShell *menu_shell) {
 		     carbon_menu->toplevel, DEBUG_SYNC);
 }
 
-#endif __x86_64__

--- a/src/gtk-mac-menu.h
+++ b/src/gtk-mac-menu.h
@@ -25,7 +25,6 @@
 
 #ifndef __GTK_MAC_MENU_H__
 #define __GTK_MAC_MENU_H__
-#ifndef __x86_64__
 
 #include <gtk/gtk.h>
 
@@ -46,5 +45,4 @@ void gtk_mac_menu_connect_window_key_handler (GtkWindow *window);
 
 G_END_DECLS
 
-#endif /* __x86_64__ */
 #endif /* __GTK_MAC_MENU_H__ */


### PR DESCRIPTION
Hello. The method `gtk_mac_bundle_get_resourcesdir` is needed by many dependent packages, it's too hard to revise them all. Could you place that back please?

Also, **gtk-mac-integration** perfectly works on my **x86_64** mac, I don't see any reason to disable headers on **x86_64** environments..
