### PR TITLE
add multimedia key and dock icon click support

### DIFF
--- a/src/GtkApplicationDelegate.c
+++ b/src/GtkApplicationDelegate.c
@@ -186,4 +186,25 @@ extern NSMenu* _gtkosx_application_dock_menu (GtkosxApplication* app);
 	shouldExit = true;
 }
 
+
+- (BOOL)applicationShouldHandleReopen:(NSApplication *)theApplication hasVisibleWindows:(BOOL)flag
+{
+	GtkosxApplication *app = g_object_new (GTKOSX_TYPE_APPLICATION, NULL);
+	guint sig = g_signal_lookup ("Reopen", GTKOSX_TYPE_APPLICATION);
+	gboolean result = FALSE;
+	static gboolean inHandler = FALSE;
+	if (inHandler) return true;
+	if (sig)
+	{
+		inHandler = TRUE;
+		g_signal_emit (app, sig, 0, flag, &result);
+	}
+
+	g_object_unref (app);
+	inHandler = FALSE;
+	if (result)
+		return YES;
+	else
+		return NO;
+}
 @end

--- a/src/GtkApplicationDelegate.c
+++ b/src/GtkApplicationDelegate.c
@@ -24,6 +24,60 @@
 #include <gtk/gtk.h>
 #include "gtkosxapplication.h"
 
+
+CGEventRef eventTapFunction (
+   CGEventTapProxy proxy,
+   CGEventType type,
+   CGEventRef event,
+   GtkApplicationDelegate *self
+) {
+	if(type == kCGEventTapDisabledByTimeout || type == kCGEventTapDisabledByUserInput)
+	{
+		printf(__FILE__": eventTapFunction disabled, calling reenable()\n");
+		[self re_enable];
+	}
+	if(type < 0 || type > 0x7fffffff){
+		printf(__FILE__": eventTapFunction invalid type: %u\n", type);
+		return event;
+	}
+	NSEvent* nsevent = [NSEvent eventWithCGEvent:event];
+	if( [nsevent type] == NSSystemDefined && [nsevent subtype] == 8 )
+	{
+		int keyCode = (([nsevent data1] & 0xFFFF0000) >> 16);
+		int keyFlags = ([nsevent data1] & 0x0000FFFF);
+		gboolean keyDown = (((keyFlags & 0xFF00) >> 8)) == 0xA;
+		gboolean keyRepeat = (keyFlags & 0x1);
+
+		printf(__FILE__ ": eventTapFunction mm(%i,%i,%i,%i)\n",
+			keyCode,
+			keyFlags,
+			keyDown,
+			keyRepeat);
+
+		GtkosxApplication *app = g_object_new (GTKOSX_TYPE_APPLICATION, NULL);
+		guint sig = g_signal_lookup ("MultiMediaKey",
+			GTKOSX_TYPE_APPLICATION);
+		gboolean result = FALSE;
+		static gboolean inHandler = FALSE;
+		if (inHandler) return event;
+		if (sig)
+		{
+			inHandler = TRUE;
+			g_signal_emit (app, sig, 0, keyCode, keyDown, keyRepeat, &result);
+		}
+		else
+		{
+			printf(__FILE__ ": signal not found\n");
+		}
+
+		g_object_unref (app);
+		inHandler = FALSE;
+		if (result)
+			return NULL;
+	}
+	return event;
+}
+
 @implementation GtkApplicationDelegate
 -(BOOL) application: (NSApplication*)theApplication openFile: (NSString*) file
 {
@@ -67,6 +121,69 @@ extern NSMenu* _gtkosx_application_dock_menu (GtkosxApplication* app);
 {
   GtkosxApplication *app = g_object_new (GTKOSX_TYPE_APPLICATION, NULL);
   return _gtkosx_application_dock_menu (app);
+}
+
+
+-(void)myThreadMainMethod:(id)object
+{
+	fprintf(stderr, "myThreadMainMethod started\n");
+	// Top-level pool
+	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+
+	CFRunLoopRef runLoop = CFRunLoopGetCurrent();
+
+	machPort = CGEventTapCreate(kCGSessionEventTap,
+	                            kCGHeadInsertEventTap,
+	                            kCGEventTapOptionDefault,
+	                            CGEventMaskBit(NSSystemDefined),
+	                            (CGEventTapCallBack)eventTapFunction,
+	                            self);
+	if (!machPort) {
+		NSException *e =
+		[NSException exceptionWithName:@"FailedToCreateEventTap"
+			reason:@"Failed to create an event tap for multimedia keys"
+			userInfo:[NSDictionary dictionary]];
+		@throw e;
+	}
+
+	CFRunLoopSourceRef runLoopSource = CFMachPortCreateRunLoopSource(NULL,
+	                                                                 machPort,
+	                                                                 0);
+
+	CFRunLoopAddSource(runLoop, runLoopSource, kCFRunLoopDefaultMode);
+	CGEventTapEnable(machPort, true);
+
+
+	do
+	{
+		[[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+	                                beforeDate:[NSDate distantFuture]];
+	}
+	while (!shouldExit);
+
+	fprintf(stderr, "myThreadMainMethod stopped\n");
+	machPort = NULL;
+
+	// Release the objects in the pool.
+	[pool release];
+}
+
+
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification
+{
+	fprintf(stderr, "applicationDidFinishLaunching\n");
+	NSThread* myThread = [[NSThread alloc] initWithTarget:self
+                                        selector:@selector(myThreadMainMethod:)
+                                        object:nil];
+
+	[myThread start];
+}
+
+
+- (void)applicationWillTerminate:(NSNotification *)aNotification
+{
+	fprintf(stderr, __FILE__": applicationWillTerminate\n");
+	shouldExit = true;
 }
 
 @end

--- a/src/GtkApplicationDelegate.h
+++ b/src/GtkApplicationDelegate.h
@@ -22,6 +22,10 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface GtkApplicationDelegate : NSObject {}
+@interface GtkApplicationDelegate : NSObject {
+@private
+CFMachPortRef machPort;
+bool shouldExit;
+}
 @end
 

--- a/src/GtkApplicationDelegate.h
+++ b/src/GtkApplicationDelegate.h
@@ -27,5 +27,7 @@
 CFMachPortRef machPort;
 bool shouldExit;
 }
+- (void)installEventTap;
+- (void)reEnableEventTap;
 @end
 

--- a/src/gtkosxapplication.c
+++ b/src/gtkosxapplication.c
@@ -284,3 +284,36 @@ gtkosx_type_application_attention_type_get_type (void)
   //Bogus GType, but there's no good reason to register this; it's only an enum
   return GTKOSX_TYPE_APPLICATION;
 }
+
+/**
+ * gtkosx_application_listen_for_multimedia_keys:
+ * @self: The GtkosxApplication pointer.
+ *
+ * Is the multimedia keys event tap active?
+ *
+ * Returns: a gboolean
+ */
+gboolean
+gtkosx_application_listen_for_multimedia_keys (GtkosxApplication *self)
+{
+  return self->priv->listen_for_multimedia_keys;
+}
+
+
+/**
+ * gtkosx_application_set_listen_for_multimedia_keys:
+ * @self: The GtkosxApplication pointer.
+ * @listen_for_multimedia_keys: Gboolean
+ *
+ * Register a global event tap to listen to multimedia keys and be able to inhibit
+ * them; TRUE activate the event tap; FALSE (default) won't activate the
+ * event tap.
+ *
+ * This can't be changed after gtkosx_application_ready is called
+ */
+void
+gtkosx_application_set_listen_for_multimedia_keys (GtkosxApplication *self,
+    gboolean listen_for_multimedia_keys)
+{
+  self->priv->listen_for_multimedia_keys = listen_for_multimedia_keys;
+}

--- a/src/gtkosxapplication.h
+++ b/src/gtkosxapplication.h
@@ -141,6 +141,12 @@ gchar *gtkosx_application_get_executable_path(void);
 gchar *gtkosx_application_get_bundle_id(void);
 gchar *gtkosx_application_get_bundle_info(const gchar *key);
 
+/* Multimedia functions */
+void gtkosx_application_set_listen_for_multimedia_keys(GtkosxApplication *self,
+					 gboolean listen_for_multimedia_keys);
+gboolean
+gtkosx_application_listen_for_multimedia_keys (GtkosxApplication *self);
+
 G_END_DECLS
 
 #endif /* __GTK_OSX_APPLICATION_H__ */

--- a/src/gtkosxapplication_quartz.c
+++ b/src/gtkosxapplication_quartz.c
@@ -491,6 +491,51 @@ g_cclosure_marshal_BOOLEAN__INT_BOOLEAN_BOOLEAN (GClosure     *closure,
 }
 
 /*
+ * g_cclosure_marshal_BOOLEAN__BOOLEAN:
+ *
+ * A private marshaller for handlers which take a boolean parameter and
+ * return a boolean.
+ */
+static void
+g_cclosure_marshal_BOOLEAN__BOOLEAN (GClosure     *closure,
+                                    GValue       *return_value G_GNUC_UNUSED,
+                                    guint         n_param_values,
+                                    const GValue *param_values,
+                                    gpointer      invocation_hint G_GNUC_UNUSED,
+                                    gpointer      marshal_data)
+{
+  typedef gboolean (*GMarshalFunc_BOOLEAN__BOOLEAN) (gpointer     data1,
+      const gboolean     arg1,
+      gpointer     data2);
+  register GMarshalFunc_BOOLEAN__BOOLEAN callback;
+  register GCClosure *cc = (GCClosure*) closure;
+  register gpointer data1, data2;
+  gboolean v_return;
+
+  g_return_if_fail (n_param_values == 2);
+
+  if (G_CCLOSURE_SWAP_DATA (closure))
+    {
+      data1 = closure->data;
+      data2 = g_value_peek_pointer (param_values + 0);
+    }
+  else
+    {
+      data1 = g_value_peek_pointer (param_values + 0);
+      data2 = closure->data;
+    }
+  callback = (GMarshalFunc_BOOLEAN__BOOLEAN) (marshal_data ? marshal_data : cc->callback);
+
+  v_return = callback (data1,
+                       g_value_get_boolean (param_values + 1),
+                       data2);
+  g_value_set_boolean (return_value, v_return);
+}
+
+
+
+
+/*
  * block_termination_accumulator:
  *
  * A signal accumulator function for the NSApplicationShouldTerminate
@@ -572,6 +617,7 @@ enum
   WillTerminate,
   OpenFile,
   MultiMediaKey,
+  Reopen,
   LastSignal
 };
 
@@ -732,6 +778,25 @@ gtkosx_application_class_init (GtkosxApplicationClass *klass)
                   0, NULL, NULL,
                   g_cclosure_marshal_BOOLEAN__INT_BOOLEAN_BOOLEAN,
                   G_TYPE_BOOLEAN, 3, G_TYPE_INT, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN);
+
+  /**
+   * GtkosxApplication::Reopen:
+   * @app: The application object
+   * @flag: are there any open windows
+   *
+   * Emitted when the user clicks on the dock icon or relaunches the application.
+   * https://developer.apple.com/library/mac/documentation/Cocoa/Reference/NSApplicationDelegate_Protocol/Reference/Reference.html#jumpTo_29
+   *
+   * Returns: Boolean indicating the application should behave by default,
+   * i.e. return false if you have handled the event yourself.
+   */
+  gtkosx_application_signals[Reopen] =
+    g_signal_new ("Reopen",
+                  GTKOSX_TYPE_APPLICATION,
+                  G_SIGNAL_NO_RECURSE | G_SIGNAL_ACTION,
+                  0, NULL, NULL,
+                  g_cclosure_marshal_BOOLEAN__BOOLEAN,
+                  G_TYPE_BOOLEAN, 1, G_TYPE_BOOLEAN);
 
 }
 

--- a/src/gtkosxapplication_quartz.c
+++ b/src/gtkosxapplication_quartz.c
@@ -452,11 +452,11 @@ g_cclosure_marshal_BOOLEAN__STRING (GClosure     *closure,
  */
 static void
 g_cclosure_marshal_BOOLEAN__INT_BOOLEAN_BOOLEAN (GClosure     *closure,
-                                    GValue       *return_value G_GNUC_UNUSED,
-                                    guint         n_param_values,
-                                    const GValue *param_values,
-                                    gpointer      invocation_hint G_GNUC_UNUSED,
-                                    gpointer      marshal_data)
+                                                 GValue       *return_value G_GNUC_UNUSED,
+                                                 guint         n_param_values,
+                                                 const GValue *param_values,
+                                                 gpointer      invocation_hint G_GNUC_UNUSED,
+                                                 gpointer      marshal_data)
 {
   typedef gboolean (*GMarshalFunc_BOOLEAN__INT_BOOLEAN_BOOLEAN) (gpointer     data1,
       const int arg1,
@@ -498,11 +498,11 @@ g_cclosure_marshal_BOOLEAN__INT_BOOLEAN_BOOLEAN (GClosure     *closure,
  */
 static void
 g_cclosure_marshal_BOOLEAN__BOOLEAN (GClosure     *closure,
-                                    GValue       *return_value G_GNUC_UNUSED,
-                                    guint         n_param_values,
-                                    const GValue *param_values,
-                                    gpointer      invocation_hint G_GNUC_UNUSED,
-                                    gpointer      marshal_data)
+                                     GValue       *return_value G_GNUC_UNUSED,
+                                     guint         n_param_values,
+                                     const GValue *param_values,
+                                     gpointer      invocation_hint G_GNUC_UNUSED,
+                                     gpointer      marshal_data)
 {
   typedef gboolean (*GMarshalFunc_BOOLEAN__BOOLEAN) (gpointer     data1,
       const gboolean     arg1,
@@ -635,6 +635,7 @@ gtkosx_application_init (GtkosxApplication *self)
   [NSApplication sharedApplication];
   self->priv = GTKOSX_APPLICATION_GET_PRIVATE (self);
   self->priv->use_quartz_accelerators = TRUE;
+  self->priv->listen_for_multimedia_keys = FALSE;
   self->priv->dock_menu = NULL;
   gdk_window_add_filter (NULL, global_event_filter_func, (gpointer)self);
   self->priv->notify = [[GtkApplicationNotificationObject alloc] init];
@@ -780,7 +781,7 @@ gtkosx_application_class_init (GtkosxApplicationClass *klass)
                   G_TYPE_BOOLEAN, 3, G_TYPE_INT, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN);
 
   /**
-   * GtkosxApplication::Reopen:
+   * GtkosxApplication::NSApplicationReopen:
    * @app: The application object
    * @flag: are there any open windows
    *
@@ -791,7 +792,7 @@ gtkosx_application_class_init (GtkosxApplicationClass *klass)
    * i.e. return false if you have handled the event yourself.
    */
   gtkosx_application_signals[Reopen] =
-    g_signal_new ("Reopen",
+    g_signal_new ("NSApplicationReopen",
                   GTKOSX_TYPE_APPLICATION,
                   G_SIGNAL_NO_RECURSE | G_SIGNAL_ACTION,
                   0, NULL, NULL,
@@ -810,6 +811,10 @@ void
 gtkosx_application_ready (GtkosxApplication *self)
 {
   [NSApp finishLaunching];
+  if(self->priv->listen_for_multimedia_keys)
+  {
+    [self->priv->delegate installEventTap];
+  }
 }
 
 /*

--- a/src/gtkosxapplication_quartz.c
+++ b/src/gtkosxapplication_quartz.c
@@ -444,6 +444,51 @@ g_cclosure_marshal_BOOLEAN__STRING (GClosure     *closure,
   g_value_set_boolean (return_value, v_return);
 }
 
+/*
+ * g_cclosure_marshal_BOOLEAN__INT_BOOLEAN_BOOLEAN:
+ *
+ * A private marshaller for handlers which take an int and to boolean parameters and
+ * return a boolean.
+ */
+static void
+g_cclosure_marshal_BOOLEAN__INT_BOOLEAN_BOOLEAN (GClosure     *closure,
+                                    GValue       *return_value G_GNUC_UNUSED,
+                                    guint         n_param_values,
+                                    const GValue *param_values,
+                                    gpointer      invocation_hint G_GNUC_UNUSED,
+                                    gpointer      marshal_data)
+{
+  typedef gboolean (*GMarshalFunc_BOOLEAN__INT_BOOLEAN_BOOLEAN) (gpointer     data1,
+      const int arg1,
+      const gboolean arg2,
+      const gboolean arg3,
+      gpointer     data2);
+  register GMarshalFunc_BOOLEAN__INT_BOOLEAN_BOOLEAN callback;
+  register GCClosure *cc = (GCClosure*) closure;
+  register gpointer data1, data2;
+  gboolean v_return;
+
+  g_return_if_fail (n_param_values == 4);
+
+  if (G_CCLOSURE_SWAP_DATA (closure))
+    {
+      data1 = closure->data;
+      data2 = g_value_peek_pointer (param_values + 0);
+    }
+  else
+    {
+      data1 = g_value_peek_pointer (param_values + 0);
+      data2 = closure->data;
+    }
+  callback = (GMarshalFunc_BOOLEAN__INT_BOOLEAN_BOOLEAN) (marshal_data ? marshal_data : cc->callback);
+
+  v_return = callback (data1,
+                       g_value_get_int (param_values + 1),
+                       g_value_get_boolean (param_values + 2),
+                       g_value_get_boolean (param_values + 3),
+                       data2);
+  g_value_set_boolean (return_value, v_return);
+}
 
 /*
  * block_termination_accumulator:
@@ -526,6 +571,7 @@ enum
   BlockTermination,
   WillTerminate,
   OpenFile,
+  MultiMediaKey,
   LastSignal
 };
 
@@ -666,6 +712,26 @@ gtkosx_application_class_init (GtkosxApplicationClass *klass)
                   0, NULL, NULL,
                   g_cclosure_marshal_BOOLEAN__STRING,
                   G_TYPE_BOOLEAN, 1, G_TYPE_STRING);
+
+  /**
+   * GtkosxApplication::MultiMediaKey:
+   * @app: The application object
+   * @keyCode: code of the key
+   * @isDown: is the key pressed
+   * @repeat: key repeat?
+   * @user_data: Data attached at connection
+   *
+   * Emitted when a multimedia key is pressed or released.
+   *
+   * Returns: Boolean indicating that the multimedia key should not be emitted.
+   */
+  gtkosx_application_signals[MultiMediaKey] =
+    g_signal_new ("MultiMediaKey",
+                  GTKOSX_TYPE_APPLICATION,
+                  G_SIGNAL_NO_RECURSE | G_SIGNAL_ACTION,
+                  0, NULL, NULL,
+                  g_cclosure_marshal_BOOLEAN__INT_BOOLEAN_BOOLEAN,
+                  G_TYPE_BOOLEAN, 3, G_TYPE_INT, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN);
 
 }
 

--- a/src/gtkosxapplicationprivate.h
+++ b/src/gtkosxapplicationprivate.h
@@ -34,6 +34,7 @@
 struct _GtkosxApplicationPrivate
 {
   gboolean use_quartz_accelerators;
+  gboolean listen_for_multimedia_keys;
   NSMenu *dock_menu;
   GtkApplicationNotificationObject *notify;
   GtkApplicationDelegate *delegate;

--- a/src/test-integration.c
+++ b/src/test-integration.c
@@ -616,8 +616,16 @@ app_will_quit_cb (GtkosxApplication *app, gpointer data)
 static gboolean
 app_open_file_cb (GtkosxApplication *app, gchar *path, gpointer user_data)
 {
-  g_print ("File open event for %s", path);
+  g_print ("File open event for %s\n", path);
   return FALSE;
+}
+
+static gboolean
+app_mm_key_cb (GtkosxApplication *app, int keyCode, gboolean isDown, gboolean isRepeat, gpointer user_data)
+{
+  g_print ("MM KEY EVENT for key %i\n", keyCode);
+  if(keyCode == 16) return TRUE;
+  else return FALSE;
 }
 
 #endif //GTKOSXAPPLICATION
@@ -851,10 +859,13 @@ main (int argc, char **argv)
                       G_CALLBACK (app_will_quit_cb), NULL);
     g_signal_connect (theApp, "NSApplicationOpenFile",
                       G_CALLBACK (app_open_file_cb), NULL);
+    g_signal_connect (theApp, "MultiMediaKey",
+                      G_CALLBACK (app_mm_key_cb), NULL);
   }
 # ifndef QUARTZ_HANDLERS
   gtkosx_application_set_use_quartz_accelerators (theApp, FALSE);
 # endif //QUARTZ_HANDLERS
+  gtkosx_application_set_listen_for_multimedia_keys (theApp, TRUE);
   gtkosx_application_ready (theApp);
   {
     const gchar *id = gtkosx_application_get_bundle_id ();


### PR DESCRIPTION
These 2 commits add
 - multimedia keys handling: ability to inhibit those keys emission (block iTunes launching) and to process them in gtk, via a new signal on the GtkOSXApplication : 'MultiMediaKey'.
- clicks on the dock or relaunch by the user (```NSApplicationDelegate``` protocol function ```applicationShouldHandleReopen:hasVisibleWindows:```)

Regarding multimedia keys handling, the events are also seen in the ```global_event_filter_func``` but I would like to give the application the ability to swallow the event, which can only be done via an event tap, (and then if it's swallowed it won't appear in the ```global_event_filter_func```).

The 'Reopen' event is necessary to handle showing again a gtk window hidden by clicking the close button, when the user clicks on the dock. This is what non document based applications like iTunes and the activity monitor do. 