### PR TITLE
Listen to NSApplicationOpenURL and signal

### DIFF
--- a/src/GtkApplicationDelegate.c
+++ b/src/GtkApplicationDelegate.c
@@ -92,4 +92,22 @@ extern NSMenu* _gtkosx_application_dock_menu (GtkosxApplication* app);
   return _gtkosx_application_dock_menu (app);
 }
 
+-(void) getUrl:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent
+{
+  NSString *url = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
+  GtkosxApplication *app = g_object_new(GTKOSX_TYPE_APPLICATION, NULL);
+  guint sig = g_signal_lookup("NSApplicationOpenURL", GTKOSX_TYPE_APPLICATION);
+  if (sig)
+    g_signal_emit(app, sig, 0, [url UTF8String]);
+  g_object_unref(app);
+}
+
+-(void)applicationWillFinishLaunching:(NSNotification *)aNotification {
+  [[NSAppleEventManager sharedAppleEventManager]
+	setEventHandler:self
+	andSelector:@selector(getUrl:withReplyEvent:)
+	forEventClass:kInternetEventClass
+	andEventID:kAEGetURL];
+}
+
 @end

--- a/src/gtkosxapplication_quartz.c
+++ b/src/gtkosxapplication_quartz.c
@@ -566,6 +566,7 @@ enum
   BlockTermination,
   WillTerminate,
   OpenFile,
+  OpenURL,
   LastSignal
 };
 
@@ -707,7 +708,24 @@ gtkosx_application_class_init (GtkosxApplicationClass *klass)
                   g_cclosure_marshal_BOOLEAN__STRING,
                   G_TYPE_BOOLEAN, 1, G_TYPE_STRING);
 
+
+  /**
+   * GtkOSXApplication::NSApplicationOpenURL:
+   *
+   * Emitted when a OpenURL event is received from operating system.
+   *
+   * Returns: Nothing
+   */
+  gtkosx_application_signals[OpenURL] =
+      g_signal_new("NSApplicationOpenURL",
+             GTKOSX_TYPE_APPLICATION,
+             G_SIGNAL_NO_RECURSE | G_SIGNAL_ACTION,
+             0, NULL, NULL,
+             g_cclosure_marshal_BOOLEAN__STRING,
+             G_TYPE_NONE, 1, G_TYPE_STRING);
+
 }
+
 
 /**
  * gtkosx_application_ready:


### PR DESCRIPTION
Enables applications to listed to OpenURL events for URL schemes
registered by the application. Registration is not handled here,
but by the Info.plist metadata