### PR TITLE
Fix invalid image alphaInfo error

### DIFF
--- a/src/gtk-mac-image-utils.c
+++ b/src/gtk-mac-image-utils.c
@@ -30,6 +30,7 @@ gtkosx_create_cgimage_from_pixbuf (GdkPixbuf *pixbuf)
 {
   CGColorSpaceRef   colorspace;
   CGDataProviderRef data_provider;
+  GCBitmapInfo      bmi;
   CGImageRef        image;
   void             *data;
   gint              rowstride;
@@ -47,11 +48,13 @@ gtkosx_create_cgimage_from_pixbuf (GdkPixbuf *pixbuf)
   data_provider = CGDataProviderCreateWithData (NULL, data,
                   pixbuf_height * rowstride,
                   NULL);
+  bmi = kCGBitmapByteOrderDefault |
+    (CGBitmapInfo)(has_alpha ? kCGImageAlphaLast : kCGImageAlphaNone);
 
   image = CGImageCreate (pixbuf_width, pixbuf_height, 8,
                          has_alpha ? 32 : 24, rowstride,
                          colorspace,
-                         has_alpha ? kCGBitmapAlphaInfoMask: 0,
+                         bmi,
                          data_provider, NULL, FALSE,
                          kCGRenderingIntentDefault);
 


### PR DESCRIPTION
I'm using gtk-mac-integration transitively from https://github.com/haskell/ThreadScope via the Haskell binding of this library for [setting the dock icon](https://github.com/haskell/ThreadScope/blob/f21d0dfa9180582477276dec6535f38a90023197/GUI/App.hs#L31) on macOS.

Recently we started getting an error when starting the application. See https://github.com/haskell/ThreadScope/issues/87 for the stack trace.

I narrowed down the issue by bisecting recent commits and it seems that a8ee762e1c7e356d4bd4f90c70c7934ac9505a93 caused it.

I'm not familiar with Core Graphics so I'm not sure this is the right fix but quick googling turned up some people complaining they had to cast `CGImageAlphaInfo` to `GCBitmapInfo`.

I've confirmed that this fixes the issue and also the compiler warnings about the implicit cast are gone.