### PR TITLE
patch from the gimp project

### DIFF
--- a/src/cocoa_menu_item.c
+++ b/src/cocoa_menu_item.c
@@ -669,10 +669,8 @@ cocoa_menu_item_add_submenu (GtkMenuShell *menu_shell,
         /* Don't want separators on the menubar */
         continue;
 
-      if (GTK_IS_SEPARATOR_MENU_ITEM (menu_item) &&
-	  (last_item == NULL || GTK_IS_SEPARATOR_MENU_ITEM (last_item)))
-	/* Don't put a separator at the top, nor make separators with
-	 * nothing between them.
+      if (GTK_IS_SEPARATOR_MENU_ITEM (menu_item) && (last_item == NULL))
+	/* Don't put a separator at the top.
 	 */
 	continue;
 


### PR DESCRIPTION
Hi,

This is the patch from the gimp project which i found as never merged to the upstream. Source of the patch is https://gitlab.gnome.org/GNOME/gimp/blob/gimp-2-8/build/osx/patches/gmi2-keep-separators-between-placeholders.patch . I also found in the network description of the patch - http://www.gimpusers.com/forums/gimp-developer/16501-gimp-2-8-on-os-x-fixes . I decided to propose it to include to the upstream, to reduce amount of local changes.